### PR TITLE
Add instructions for running the demo out of the repository.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,11 @@ and then run it::
 
 This will pop up a GUI window.
 
+If you have cloned the toga-demo repository, you can run the demo like this::
+
+    $ pip3 install toga
+    $ python3 -m toga_demo
+
 Community
 ---------
 


### PR DESCRIPTION
I had cloned the repo, and wanted to run the code straight from the repo, to make it easier to play with the code. Being relatively new to python, I had to google the instructions on how to run the application from the `__main__.py` file, and want to spare others from doing the same.